### PR TITLE
build(package.json): devdepに@types/wsを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,15 @@
       "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
       "dev": true
     },
+    "@types/ws": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
+      "integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.30.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^13.13.4",
+    "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint": "^6.8.0",


### PR DESCRIPTION
cloneして
```
npm i
npm run compile
```
すると
```
$ npm run compile

> typescript-template@0.1.0 compile /path/to/workdir
> tsc -p .

node_modules/discord.js/typings/index.d.ts:18:30 - error TS7016: Could not find a declaration file for module 'ws'. '/path/to/workdir/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm install @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

18   import * as WebSocket from 'ws';
                                ~~~~


Found 1 error.
```
というエラーが出ます。[discord.jsのissue](https://github.com/discordjs/discord.js/issues/4011)を見ると@typesは自分で入れてくれとのことなのでdevDependenciesに入れてみました。